### PR TITLE
Add Jenkins node label selection

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=node-exporter

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,15 +4,17 @@ pipeline {
         stage('Deploy') {
             steps {
                 script {
-                    def targetNodes = []
+                    def targetNodes
                     if (env.BRANCH_NAME == 'main') {
-                        ['build', 'production', 'observability'].each { label ->
-                            targetNodes += nodesByLabel(label)
-                        }
-                        targetNodes = targetNodes.unique()
+                        // Collect every node configured in Jenkins
+                        targetNodes = jenkins.model.Jenkins.instance.nodes.collect { it.nodeName }
+                        // Include the controller in case it's not in the list
+                        targetNodes += 'master'
                     } else {
+                        // Only use build nodes for feature branches
                         targetNodes = nodesByLabel('build')
                     }
+                    targetNodes = targetNodes.unique()
 
                     def tasks = [:]
                     for (n in targetNodes) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,31 @@
+pipeline {
+    agent none
+    stages {
+        stage('Deploy') {
+            steps {
+                script {
+                    def targetNodes = []
+                    if (env.BRANCH_NAME == 'main') {
+                        ['build', 'production', 'observability'].each { label ->
+                            targetNodes += nodesByLabel(label)
+                        }
+                        targetNodes = targetNodes.unique()
+                    } else {
+                        targetNodes = nodesByLabel('build')
+                    }
+
+                    def tasks = [:]
+                    for (n in targetNodes) {
+                        tasks[n] = {
+                            node(n) {
+                                checkout scm
+                                sh 'docker compose up -d'
+                            }
+                        }
+                    }
+                    parallel tasks
+                }
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,15 +4,15 @@ pipeline {
         stage('Deploy') {
             steps {
                 script {
-                    def targetNodes
+                    def targetNodes = []
                     if (env.BRANCH_NAME == 'main') {
-                        // Collect every node configured in Jenkins
-                        targetNodes = jenkins.model.Jenkins.instance.nodes.collect { it.nodeName }
-                        // Include the controller in case it's not in the list
-                        targetNodes += 'master'
+                        // Gather nodes from common deployment labels
+                        targetNodes += nodesByLabel('build')
+                        targetNodes += nodesByLabel('production')
+                        targetNodes += nodesByLabel('observability')
                     } else {
                         // Only use build nodes for feature branches
-                        targetNodes = nodesByLabel('build')
+                        targetNodes += nodesByLabel('build')
                     }
                     targetNodes = targetNodes.unique()
 


### PR DESCRIPTION
## Summary
- configure docker compose project name
- run deployments on nodes with build, production, or observability labels when main is built
- fall back to build labeled nodes otherwise

## Testing
- `docker compose config` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d26bb75908330ae377a3a8227bda7